### PR TITLE
Enable group swapping by default

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,6 +15,7 @@ SRC_SRC=bls_c256.cpp bls_c384.cpp bls_c384_256.cpp bls_c512.cpp
 TEST_SRC=bls256_test.cpp bls384_test.cpp bls384_256_test.cpp bls_c256_test.cpp bls_c384_test.cpp bls_c384_256_test.cpp bls_c512_test.cpp
 SAMPLE_SRC=bls256_smpl.cpp bls384_smpl.cpp
 
+BLS_SWAP_G?=1
 CFLAGS+=-I$(MCL_DIR)/include
 ifneq ($(MCL_MAX_BIT_SIZE),)
   CFLAGS+=-DMCL_MAX_BIT_SIZE=$(MCL_MAX_BIT_SIZE)


### PR DESCRIPTION
This is to deal with common mistakes in Harmony binary builds.  To disable group swapping, one can run: `make BLS_SWAP_G=0`
